### PR TITLE
Update deploy script to target branch name

### DIFF
--- a/scripts/azure/deploy_artifact.sh
+++ b/scripts/azure/deploy_artifact.sh
@@ -2,6 +2,6 @@
 
 set -ev
 
-vendor/bin/blt artifact:deploy --commit-msg "Automated commit by Azure Pipelines for Build $BUILD_BUILDID" --branch "$BUILD_SOURCEBRANCH-build" --no-interaction --verbose
+vendor/bin/blt artifact:deploy --commit-msg "Automated commit by Azure Pipelines for Build $BUILD_BUILDID" --branch "$BUILD_SOURCEBRANCHNAME-build" --no-interaction --verbose
 
 set +v


### PR DESCRIPTION
Changes Azure variable to reference branch name instead of remote ref.