### PR TITLE
Fix error 'Command tests:all is not defined'.

### DIFF
--- a/scripts/azure/test.sh
+++ b/scripts/azure/test.sh
@@ -2,6 +2,6 @@
 
 set -ev
 
-vendor/bin/blt tests:all --define drush.alias='${drush.aliases.ci}' -D behat.web-driver=chrome --no-interaction --ansi --verbose
+vendor/bin/blt tests --define drush.alias='${drush.aliases.ci}' -D behat.web-driver=chrome --no-interaction --ansi --verbose
 
 set +v


### PR DESCRIPTION
blt tests:all command does not exist. Invoke 'blt tests' instead.

> vendor/bin/blt tests:all --define drush.alias='${drush.aliases.ci}' -D behat.web-driver=chrome --no-interaction --ansi --verbose
> 
> In Application.php line 676:
>                                                                   
>   [Symfony\Component\Console\Exception\CommandNotFoundException]  
>   Command "tests:all" is not defined.                             
>                                                                   
>   Did you mean one of these?                                      
>       artifact:install:drupal                                     
>       drupal:install                                              
>       sync:all                                                    
>       sync:all:db                                                 
>       tests                                                       
>       tests:frontend                                              
>       tests:frontend:run                                          
>       tests:security-composer                                     
>       tests:security-drupal                                       
>       tests:server:kill                                           
>       tests:server:start